### PR TITLE
Create concourse pipeline & IAM roles in scripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
 gem "octokit"
+gem "aws-sdk-core"
 gem "aws-sdk-codecommit"

--- a/concourse.yml
+++ b/concourse.yml
@@ -1,0 +1,62 @@
+---
+resources:
+  - name: mirror-repos-git
+    type: git
+    source:
+      uri: https://github.com/alphagov/govuk-repo-mirror.git
+      branch: master
+
+  - name: every-two-hours
+    type: time
+    source:
+      interval: 2h
+
+
+jobs:
+  - name: mirror-repos
+    serial: true
+    plan:
+      - get: mirror-repos-git
+        trigger: true
+
+      - get: every-two-hours
+        trigger: true
+
+      - task: get-repos
+        timeout: 30m
+        config:
+          params:
+            ENSURE_DEFAULT_BRANCH: true
+            GITHUB_ACCESS_TOKEN: ((mirror_repos_github_api_token))
+            ROLE_ARN: arn:aws:iam::((govuk_tools_account_id)):role/govuk-concourse-codecommit-role
+            GIT_SSH_PRIVATE_KEY: ((git_ssh_private_key))
+            AWS_CODECOMMIT_USER_ID: ((aws_codecommit_user_id))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.6.0
+          inputs:
+            - name: mirror-repos-git
+          run:
+            dir: mirror-repos-git
+            path: bash
+            args:
+              - -c
+              - |
+                set -ueo pipefail
+
+                apt-get update  --yes
+                apt-get install --yes awscli
+
+                echo "$GIT_SSH_PRIVATE_KEY" \
+                | base64 --decode           \
+                | openssl rsa -inform DER   \
+                > /tmp/git_ssh_key
+
+                chmod 400 /tmp/git_ssh_key
+                export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /tmp/git_ssh_key"
+
+                bundle install
+                ./mirror_repos

--- a/concourse.yml
+++ b/concourse.yml
@@ -1,4 +1,11 @@
 ---
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
 resources:
   - name: mirror-repos-git
     type: git
@@ -10,6 +17,11 @@ resources:
     type: time
     source:
       interval: 2h
+
+  - name: govuk-platform-health-slack
+    type: slack-notification
+    source:
+      url: ((govuk_platform_health_slack_webhook_url))
 
 
 jobs:
@@ -60,3 +72,14 @@ jobs:
 
                 bundle install
                 ./mirror_repos
+        on_failure:
+          put: govuk-platform-health-slack
+          params:
+            channel: '#govuk-2ndline'
+            username: cd
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              operations/mirror-repos has failed
+              http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME

--- a/ensure_aws_default_branch
+++ b/ensure_aws_default_branch
@@ -7,9 +7,10 @@ require 'aws-sdk-codecommit'
 # This script is optionally used to update the default branch for existing repos.
 #
 aws_cc_client = Aws::CodeCommit::Client.new(
-  access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-  secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-  region: ENV['AWS_REGION'],
+  access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
+  secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+  session_token: ENV.fetch('AWS_SESSION_TOKEN', nil),
+  region: ENV.fetch('AWS_REGION'),
 )
 
 MASTER_BRANCH = "master".freeze

--- a/ensure_aws_repos_exist
+++ b/ensure_aws_repos_exist
@@ -4,9 +4,10 @@ require 'bundler'
 require 'aws-sdk-codecommit'
 
 aws_cc_client = Aws::CodeCommit::Client.new(
-  access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-  secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-  region: ENV['AWS_REGION'],
+  access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
+  secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+  session_token: ENV.fetch('AWS_SESSION_TOKEN', nil),
+  region: ENV.fetch('AWS_REGION'),
 )
 
 github_repos = ARGV

--- a/get_github_repos
+++ b/get_github_repos
@@ -3,7 +3,7 @@
 require 'bundler'
 require 'octokit'
 
-client = Octokit::Client.new(access_token: ENV['GITHUB_ACCESS_TOKEN'])
+client = Octokit::Client.new(access_token: ENV.fetch('GITHUB_ACCESS_TOKEN'))
 client.auto_paginate = true
 
 # We set this in order to retrieve topics from the GitHub API. Once this

--- a/mirror_repos
+++ b/mirror_repos
@@ -1,6 +1,20 @@
 #! /bin/bash
 
+set -ueo pipefail
+
+export AWS_REGION=eu-west-2
+export AWS_DEFAULT_REGION=eu-west-2
+
 base_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function with_credentials {
+  unset AWS_ACCESS_KEY_ID
+  unset AWS_SECRET_ACCESS_KEY
+  unset AWS_SESSION_TOKEN
+  eval $(./set_credentials)
+}
+
+with_credentials
 
 echo "Finding Github repos tagged with 'govuk'..."
 repos=$(${base_dir}/get_github_repos)
@@ -12,6 +26,8 @@ ${base_dir}/ensure_aws_repos_exist ${repos}
 
 for repo in ${repos}; do
 
+  with_credentials
+
   git config --global credential.helper '!aws codecommit credential-helper $@'
   git config --global credential.UseHttpPath true
 
@@ -22,13 +38,30 @@ for repo in ${repos}; do
 
   if [ ${github_md5} != ${aws_cc_md5} ]; then
     echo "updating"
-    if [ ! -d ${repo}.git ]; then
-      git init --bare ${repo}.git
-    fi
-
     git="git --git-dir ${repo}.git"
-    ${git} fetch https://${GITHUB_ACCESS_TOKEN}@github.com/alphagov/${repo} +refs/heads/*:refs/heads/* --prune
-    ${git} push --mirror https://git-codecommit.${AWS_REGION}.amazonaws.com/v1/repos/${repo}
+
+    github_remote="ssh://git@github.com/alphagov/${repo}"
+    aws_remote="ssh://${AWS_CODECOMMIT_USER_ID}@git-codecommit.${AWS_REGION}.amazonaws.com/v1/repos/${repo}"
+
+    echo "Fetching ${repo}"
+    ${git} clone --mirror "${github_remote}"
+
+    echo "Doing some cleanup for ${repo}"
+    ${git} reflog expire --expire-unreachable=now --all
+    ${git} gc            --prune=now
+
+    echo "Pushing ${repo} --tags --force"
+    ${git} push --force --quiet --tags "${aws_remote}"
+
+    echo "Pushing ${repo} --all --force"
+    ${git} push --force --quiet --all "${aws_remote}"
+
+    echo "Manually pushing ${repo}"
+    ${git} push ${aws_remote} +refs/remotes/origin/*:refs/heads/*
+    ${git} push ${aws_remote} +refs/tags/*:refs/tags/*
+
+    echo "Deleting local copy ${repo}.git"
+    rm -rf "${repo}.git"
   else
     echo "ok"
   fi

--- a/set_credentials
+++ b/set_credentials
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require 'aws-sdk-core'
+require 'json'
+
+creds = Aws::STS::Client
+  .new(region: 'eu-west-2')
+  .assume_role(
+    role_arn: ENV.fetch('ROLE_ARN'),
+    role_session_name: 'concourse'
+  )
+  .credentials
+
+
+puts <<~CREDS
+  export AWS_ACCESS_KEY_ID='#{creds.access_key_id}'
+  export AWS_SECRET_ACCESS_KEY='#{creds.secret_access_key}'
+  export AWS_SESSION_TOKEN='#{creds.session_token}'
+CREDS


### PR DESCRIPTION
What
----

Creates a Concourse pipeline which mirrors repos to the GOV.UK Tools AWS account.

How to review
----

- Code review
- Run the `mirror-repos` job in [CD](https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/operations)

Ramifications
----

This may break the Git DR mirroring until it is switched over to the tools account

Todo
----

- [x] Slack notifications on failure

Further work
----

Move the pipeline from this repo into a more natural place for an `operations` pipeline

