### PR TITLE
Handle missing master branch

### DIFF
--- a/ensure_aws_default_branch
+++ b/ensure_aws_default_branch
@@ -26,10 +26,14 @@ loop do
 end
 
 aws_cc_repos.flatten.each do |repo_name|
-  resp = aws_cc_client.get_repository(repository_name: repo_name)
-  default_branch = resp.repository_metadata.default_branch
-  if default_branch && default_branch != MASTER_BRANCH
-    puts "Repo #{repo_name} has default branch: #{default_branch}, updating to '#{MASTER_BRANCH}'"
-    aws_cc_client.update_default_branch(default_branch_name: MASTER_BRANCH, repository_name: repo_name)
+  begin
+    resp = aws_cc_client.get_repository(repository_name: repo_name)
+    default_branch = resp.repository_metadata.default_branch
+    if default_branch && default_branch != MASTER_BRANCH
+      puts "Repo #{repo_name} has default branch: #{default_branch}, updating to '#{MASTER_BRANCH}'"
+      aws_cc_client.update_default_branch(default_branch_name: MASTER_BRANCH, repository_name: repo_name)
+    end
+  rescue Aws::CodeCommit::Errors::BranchDoesNotExistException
+    puts "Default branch not set since '#{MASTER_BRANCH}' does not exist"
   end
 end


### PR DESCRIPTION
This commit adds an exception handler when attempting to set the default branch for a repo in AWS CodeCommit to a non-existant master branch. This can happen for repos that have just been created, or repos used for GitHub Pages.