### PR TITLE
Slow down mirroring

### DIFF
--- a/mirror_repos
+++ b/mirror_repos
@@ -65,8 +65,11 @@ for repo in ${repos}; do
   else
     echo "ok"
   fi
+  
+  sleep 2
 done
 
 if [ "$ENSURE_DEFAULT_BRANCH" == "true" ]; then
+  sleep 10
   ${base_dir}/ensure_aws_default_branch
 fi


### PR DESCRIPTION
This commit adds a couple of `sleep` commands to pause for 2 seconds between each repository and 10 seconds before setting default branches to avoid exceeding AWS request thresholds.