### PR TITLE
Slow down default branch checking and setting

### DIFF
--- a/ensure_aws_default_branch
+++ b/ensure_aws_default_branch
@@ -37,4 +37,6 @@ aws_cc_repos.flatten.each do |repo_name|
   rescue Aws::CodeCommit::Errors::BranchDoesNotExistException
     puts "Default branch not set since '#{MASTER_BRANCH}' does not exist"
   end
+  
+  sleep 2
 end


### PR DESCRIPTION
This commit adds a `sleep` to slow down the rate at which the default branch checking script queries AWS CodeCommit.