### PR TITLE
Adding Docker Hub Authentication Details

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -5,6 +5,8 @@ resource_types:
     source:
       repository: cfcommunity/slack-notification-resource
       tag: latest
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
 
 resources:
   - name: mirror-repos-git
@@ -58,6 +60,8 @@ jobs:
             source:
               repository: ruby
               tag: 2.6.6
+              username: ((docker_hub_username))
+              password: ((docker_hub_authtoken))
           inputs:
             - name: mirror-repos-git
           run:


### PR DESCRIPTION
This is to address the problem of rate limiting that docker hub is
introducing on un-authenticated accounts.