### PR TITLE
Alert based on reliability, not single failures

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -1,4 +1,16 @@
 ---
+
+#
+# NOTE: There's a Grafana alert set up for the reliability of this pipeline:
+#
+#       https://grafana.monitoring.cd.gds-reliability.engineering/d/1go_x9sMz/concourse-alerts?orgId=1
+#
+#       This will alert #govuk-2ndline if this job's reliability drops below
+#       70% over the course of a day. It relies on the name of the pipeline
+#       (operations) and the task (mirror-repos). The #re-autom8 team can give
+#       you edit access to Grafana if you need to update the alert.
+#
+
 resource_types:
   - name: slack-notification
     type: docker-image
@@ -85,15 +97,4 @@ jobs:
 
                 bundle install
                 ./mirror_repos
-        on_failure:
-          put: govuk-2ndline-slack
-          params:
-            channel: '#govuk-2ndline'
-            username: 'GOV.UK Repo Mirror'
-            icon_emoji: ':concourse:'
-            silent: true
-            text: |
-              :kaboom:
-              The operations/mirror-repos Concourse job has failed
-              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
-              See https://docs.publishing.service.gov.uk/manual/repository-mirroring.html for more details of this job.
+


### PR DESCRIPTION
At the moment, this concourse job will alert #govuk-2ndline on slack if
there's a single failure.

The job isn't 100% reliable though, so these failures happen
semi-regularly. This makes the channel noisy, and inevitably leads to
alert blindness.

Instead, I propose that we alert based on the metrics for this pipeline:

https://grafana.monitoring.cd.gds-reliability.engineering/d/1go_x9sMz/concourse-alerts?orgId=1

Big Concourse ships its metrics to Prometheus, which can then be used in
Grafana.

I've set up an alert in Grafana (by hand - no infra-as-code yet) which
will ping slack if the reliability of this job falls below 70% for a
rolling 1 day window.

With this in place, we can remove the notification that fires every time
the job fails.

Alternative option
------------------

https://github.com/alphagov/govuk-repo-mirror/pull/16

Instead of alerting based on metrics, we could configure the
mirror-repos task to retry several times. This would be my preference
ordinarily, but I'm a little concerned about putting a retry on a job
which has a 90 minute timeout and regularly takes > 1 hour to run.