### PR TITLE
Retry mirror-repos on failure

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -46,6 +46,7 @@ jobs:
         trigger: true
 
       - task: get-repos
+        attempts: 2
         timeout: 90m
         config:
           params:


### PR DESCRIPTION
At the moment, this concourse job will alert #govuk-2ndline on slack if
there's a single failure.

The job isn't 100% reliable though, so these failures happen
semi-regularly. This makes the channel noisy, and inevitably leads to
alert blindness.

It's rare that the job fails twice in a row, so putting in a single
retry should make this reliable enough that the alert is usually useful.

Alternative option
------------------

We could alert based on job reliability metrics, instead of a single
failure. This would reduce the noisy alerts without needing a retry.

https://github.com/alphagov/govuk-repo-mirror/pull/15