### PR TITLE
Support main default branches

### DIFF
--- a/ensure_aws_default_branch
+++ b/ensure_aws_default_branch
@@ -13,8 +13,6 @@ aws_cc_client = Aws::CodeCommit::Client.new(
   region: ENV.fetch('AWS_REGION'),
 )
 
-MASTER_BRANCH = "master".freeze
-
 aws_cc_repos = []
 next_token = nil
 
@@ -26,17 +24,27 @@ loop do
 end
 
 aws_cc_repos.flatten.each do |repo_name|
+  target_default_branch = "master"
+
+  begin
+    resp = aws_cc_client.get_branch(repository_name: repo_name, branch_name: "main")
+    target_default_branch = "main"
+  rescue Aws::CodeCommit::Errors::BranchDoesNotExistException
+    puts "Main branch does not exist, will set default branch to master."
+  end
+
   begin
     puts "Getting current default branch for #{repo_name} repo"
     resp = aws_cc_client.get_repository(repository_name: repo_name)
-    default_branch = resp.repository_metadata.default_branch
-    if default_branch && default_branch != MASTER_BRANCH
-      puts "Repo #{repo_name} has default branch: #{default_branch}, updating to '#{MASTER_BRANCH}'"
-      aws_cc_client.update_default_branch(default_branch_name: MASTER_BRANCH, repository_name: repo_name)
+    current_default_branch = resp.repository_metadata.default_branch
+
+    if current_default_branch && current_default_branch != target_default_branch
+      puts "Repo #{repo_name} has default branch: #{current_default_branch}, updating to '#{target_default_branch}'"
+      aws_cc_client.update_default_branch(default_branch_name: target_default_branch, repository_name: repo_name)
     end
   rescue Aws::CodeCommit::Errors::BranchDoesNotExistException
-    puts "Default branch not set since '#{MASTER_BRANCH}' does not exist"
+    puts "Default branch not set since '#{target_default_branch}' does not exist"
   end
-  
+
   sleep 2
 end


### PR DESCRIPTION
This sets the default branch in a CodeCommit repo to "main" rather than "master" if the "main" branch exists.