### PR TITLE
Fix name of git resource in concourse pipeline

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -31,10 +31,10 @@ resources:
 jobs:
   - name: update-pipeline
     plan:
-      - get: git-master
+      - get: mirror-repos-git
         trigger: true
       - set_pipeline: operations
-        file: git-master/concourse.yml
+        file: mirror-repos-git/concourse.yml
 
   - name: mirror-repos
     serial: true


### PR DESCRIPTION
This has already been applied to concourse from a branch. You can see the job failing to set the branch back to master here:

(VPN required) https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/operations/jobs/update-pipeline/builds/1

```
> invalid pipeline:
> - invalid jobs:
> 	jobs.update-pipeline.plan.do[0].get(git-master): unknown resource 'git-master'
```

