### PR TITLE
Increase mirror job timeout by 30m

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -47,7 +47,7 @@ jobs:
 
       - task: get-repos
         attempts: 2
-        timeout: 90m
+        timeout: 2h
         config:
           params:
             ENSURE_DEFAULT_BRANCH: true


### PR DESCRIPTION
The job usually takes 1.5h, so this should give it enough time to complete.

We could also look at making this more efficient.