### PR TITLE
Add bundler/setup to other Ruby files too

### DIFF
--- a/ensure_aws_default_branch
+++ b/ensure_aws_default_branch
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 
-require 'bundler'
+require 'bundler/setup'
 require 'aws-sdk-codecommit'
 
 # Aws::CodeCommit::Client#create_repository doesn't set the default branch

--- a/ensure_aws_repos_exist
+++ b/ensure_aws_repos_exist
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 
-require 'bundler'
+require 'bundler/setup'
 require 'aws-sdk-codecommit'
 
 aws_cc_client = Aws::CodeCommit::Client.new(

--- a/get_github_repos
+++ b/get_github_repos
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 
-require 'bundler'
+require 'bundler/setup'
 require 'octokit'
 
 client = Octokit::Client.new(access_token: ENV.fetch('GITHUB_ACCESS_TOKEN'))

--- a/mirror_repos
+++ b/mirror_repos
@@ -7,15 +7,6 @@ export AWS_DEFAULT_REGION=eu-west-2
 
 base_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-function with_credentials {
-  unset AWS_ACCESS_KEY_ID
-  unset AWS_SECRET_ACCESS_KEY
-  unset AWS_SESSION_TOKEN
-  eval $(./set_credentials)
-}
-
-with_credentials
-
 echo "Finding Github repos tagged with 'govuk'..."
 repos=$(${base_dir}/get_github_repos)
 
@@ -65,7 +56,7 @@ for repo in ${repos}; do
   else
     echo "ok"
   fi
-  
+
   sleep 2
 done
 


### PR DESCRIPTION
NB, I've figured out a quick way of testing things out on the Jenkins machine:

```
$ govuk_puppet --disable "Chris Ashton testing"
# prevents Puppet from resetting everything every 30 mins

$ sudo vi /etc/jenkins_jobs/jobs/mirror_github_repositories.yaml
# make changes to the job config

$ /usr/local/bin/jenkins-jobs update --delete-old /etc/jenkins_jobs/jobs/
# rebuild the job, which you can now re-run in https://deploy.integration.publishing.service.gov.uk/job/Mirror_Github_Repositories with your latest changes
```